### PR TITLE
Image cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.14.4-stretch AS gnbsim
+FROM golang:1.14.4-stretch AS sim
 
 LABEL maintainer="ONF <omec-dev@opennetworking.org>"
 
@@ -13,4 +13,8 @@ RUN apt-get -y install ethtool
 RUN cd $GOPATH/src && mkdir -p gnbsim
 COPY . $GOPATH/src/gnbsim 
 RUN cd $GOPATH/src/gnbsim && go build -mod=vendor
-WORKDIR $GOPATH/src/gnbsim
+
+FROM sim AS gnbsim
+RUN mkdir -p /gnbsim/bin
+COPY --from=sim $GOPATH/src/gnbsim/gnbsim /gnbsim/bin/
+WORKDIR /gnbsim/bin

--- a/factory/config.go
+++ b/factory/config.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	GNBSIM_EXPECTED_CONFIG_VERSION string = "1.0.0"
-	GNBSIM_DEFAULT_CONFIG_PATH            = "/free5gc/config/gnb.conf"
+	GNBSIM_DEFAULT_CONFIG_PATH            = "/gnbsim/config/gnb.conf"
 )
 
 type Config struct {


### PR DESCRIPTION
1) Removal of reference to free5gc in image path
2) Image should not have code. Since in case we share image
   with 3rd party companies we need to make sure that code
   is not shared in image.
3) we have some gnbsim image path assumption in aether-in-a-box.
   So making sure that workdirectory is kept in such a way that
   ./gnbsim runs without any issue. Default config path updated
   in the code.