### PR TITLE
3 changes to make gnb more user friendly,

### DIFF
--- a/common/messages.go
+++ b/common/messages.go
@@ -117,5 +117,8 @@ type UeMessage struct {
 	// Number of user data packets to be generated as directed by profile
 	UserDataPktCount int
 
+	// default destination of data pkt
+	DefaultAs string
+
 	CommChan chan InterfaceMessage
 }

--- a/config/gnbsim.yaml
+++ b/config/gnbsim.yaml
@@ -9,11 +9,13 @@ info:
   description: GNBSIM initial local configuration
 
 configuration:
+  singleInterface: false #default value
   gnbs: # pool of gNodeBs
     gnb1:
       n2IpAddr: # gNB N2 interface IP address used to connect to AMF 
       n2Port: 9487 # gNB N2 Port used to connect to AMF
-      n3IpAddr: 192.168.251.5 # gNB N3 interface IP address used to connect to UPF
+      n3IpAddr: 192.168.251.5 # gNB N3 interface IP address used to connect to UPF. when singleInterface mode is false
+      #n3IpAddr: "POD_IP" # when gnb is deployed in singleInterface mode
       n3Port: 2152 # gNB N3 Port used to connect to UPF
       name: gnb1 # gNB name that uniquely identify a gNB within application
       globalRanId:
@@ -43,6 +45,7 @@ configuration:
       gnbName: gnb1 # gNB to be used for this profile
       startImsi: 208930100007487
       ueCount: 5
+      defaultAs: "192.168.250.1" #default icmp pkt destination
       plmnId: # Public Land Mobile Network ID, <PLMN ID> = <MCC><MNC>
         mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)
         mnc: 93 # Mobile Network Code (2 or 3 digits string, digit: 0~9)
@@ -52,6 +55,7 @@ configuration:
       gnbName: gnb1 # gNB to be used for this profile
       startImsi: 208930100007492 # First IMSI. Subsequent values will be used if ueCount is more than 1
       ueCount: 5 # Number of UEs for for which the profile will be executed
+      defaultAs: "192.168.250.1" #default icmp pkt destination
       plmnId: # Public Land Mobile Network ID, <PLMN ID> = <MCC><MNC>. Should match startImsi
         mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)
         mnc: 93 # Mobile Network Code (2 or 3 digits string, digit: 0~9)
@@ -62,6 +66,7 @@ configuration:
       gnbName: gnb1 # gNB to be used for this profile
       startImsi: 208930100007497 # First IMSI. Subsequent values will be used if ueCount is more than 1
       ueCount: 5 # Number of UEs for for which the profile will be executed
+      defaultAs: "192.168.250.1" #default icmp pkt destination
       plmnId: # Public Land Mobile Network ID, <PLMN ID> = <MCC><MNC>. Should match startImsi
         mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)
         mnc: 93 # Mobile Network Code (2 or 3 digits string, digit: 0~9)
@@ -71,6 +76,7 @@ configuration:
       gnbName: gnb1 # gNB to be used for this profile
       startImsi: 208930100007497 # First IMSI. Subsequent values will be used if ueCount is more than 1
       ueCount: 5 # Number of UEs for for which the profile will be executed
+      defaultAs: "192.168.250.1" #default icmp pkt destination
       plmnId: # Public Land Mobile Network ID, <PLMN ID> = <MCC><MNC>. Should match startImsi
         mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)
         mnc: 93 # Mobile Network Code (2 or 3 digits string, digit: 0~9)  
@@ -80,6 +86,7 @@ configuration:
       gnbName: gnb1 # gNB to be used for this profile
       startImsi: 208930100007497 # First IMSI. Subsequent values will be used if ueCount is more than 1
       ueCount: 5 # Number of UEs for for which the profile will be executed
+      defaultAs: "192.168.250.1" #default icmp pkt destination
       plmnId: # Public Land Mobile Network ID, <PLMN ID> = <MCC><MNC>. Should match startImsi
         mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)
         mnc: 93 # Mobile Network Code (2 or 3 digits string, digit: 0~9)
@@ -89,6 +96,7 @@ configuration:
       gnbName: gnb1 # gNB to be used for this profile
       startImsi: 208930100007497 # First IMSI. Subsequent values will be used if ueCount is more than 1
       ueCount: 1 # Number of UEs for for which the profile will be executed
+      defaultAs: "192.168.250.1" #default icmp pkt destination
       perUserTimeout: 10 #if no expected event received in this time then treat it as failure
       plmnId: # Public Land Mobile Network ID, <PLMN ID> = <MCC><MNC>. Should match startImsi
         mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)

--- a/factory/config.go
+++ b/factory/config.go
@@ -11,6 +11,7 @@ package factory
 
 import (
 	"fmt"
+	"os"
 
 	gnbctx "github.com/omec-project/gnbsim/gnodeb/context"
 	profctx "github.com/omec-project/gnbsim/profile/context"
@@ -33,8 +34,9 @@ type Info struct {
 }
 
 type Configuration struct {
-	Gnbs     map[string]*gnbctx.GNodeB `yaml:"gnbs"`
-	Profiles []*profctx.Profile        `yaml:"profiles"`
+	Gnbs            map[string]*gnbctx.GNodeB `yaml:"gnbs"`
+	Profiles        []*profctx.Profile        `yaml:"profiles"`
+	SingleInterface bool                      `yaml:"singleInterface"`
 }
 
 type Logger struct {
@@ -60,6 +62,14 @@ func (c *Config) Validate() (err error) {
 
 	if len(c.Configuration.Gnbs) == 0 {
 		return fmt.Errorf("no gnbs configured")
+	}
+
+	if c.Configuration.SingleInterface == true {
+		for _, gnb := range c.Configuration.Gnbs {
+			if gnb.GnbN3Ip == "POD_IP" {
+				gnb.GnbN3Ip = os.Getenv("POD_IP")
+			}
+		}
 	}
 
 	if len(c.Configuration.Profiles) == 0 {

--- a/profile/context/profile.go
+++ b/profile/context/profile.go
@@ -28,6 +28,7 @@ type Profile struct {
 	Plmn           *models.PlmnId `yaml:"plmnId"`
 	DataPktCount   int            `yaml:"dataPktCount"`
 	PerUserTimeout uint32         `yaml:"perUserTimeout"`
+	DefaultAs      string         `yaml:"defaultAs"`
 
 	// Profile routine reads messages from other entities on this channel
 	// Entities can be SimUe, Main routine.

--- a/realue/context/pdusession.go
+++ b/realue/context/pdusession.go
@@ -28,6 +28,7 @@ type PduSession struct {
 	PduAddress       net.IP
 	SeqNum           int
 	ReqDataPktCount  int
+	DefaultAs        string
 	TxDataPktCount   int
 	RxDataPktCount   int
 	LastDataPktRecvd bool

--- a/realue/worker/pdusessworker/handler.go
+++ b/realue/worker/pdusessworker/handler.go
@@ -53,8 +53,8 @@ func SendIcmpEchoRequest(pduSess *realuectx.PduSession) (err error) {
 		Flags:    0,
 		TotalLen: IPV4_MIN_HEADER_LEN + ICMP_HEADER_LEN + icmpPayloadLen,
 		TTL:      64,
-		Src:      pduSess.PduAddress,                 // ue IP address
-		Dst:      net.ParseIP("192.168.250.1").To4(), // upstream router interface connected to Gi
+		Src:      pduSess.PduAddress,                   // ue IP address
+		Dst:      net.ParseIP(pduSess.DefaultAs).To4(), // upstream router interface connected to Gi
 		ID:       1,
 	}
 	checksum := test.CalculateIpv4HeaderChecksum(&ipv4hdr)
@@ -165,6 +165,7 @@ func HandleDataPktGenRequestEvent(pduSess *realuectx.PduSession,
 	intfcMsg common.InterfaceMessage) (err error) {
 	cmd := intfcMsg.(*common.UeMessage)
 	pduSess.ReqDataPktCount = cmd.UserDataPktCount
+	pduSess.DefaultAs = cmd.DefaultAs
 	err = SendIcmpEchoRequest(pduSess)
 	if err != nil {
 		return fmt.Errorf("failed to send icmp echo req:%v", err)

--- a/simue/handler.go
+++ b/simue/handler.go
@@ -450,6 +450,10 @@ func HandleProcedure(ue *simuectx.SimUe) {
 		ue.Log.Infoln("Initiating User Data Packet Generation Procedure")
 		msg := &common.UeMessage{}
 		msg.UserDataPktCount = ue.ProfileCtx.DataPktCount
+		if ue.ProfileCtx.DefaultAs == "" {
+			ue.ProfileCtx.DefaultAs = "192.168.250.1" // default destination for AIAB
+		}
+		msg.DefaultAs = ue.ProfileCtx.DefaultAs
 		msg.Event = common.DATA_PKT_GEN_REQUEST_EVENT
 
 		/* TODO: Solve timing issue. Currently UE may start sending user data


### PR DESCRIPTION
1. gNB can be installed with single interface or multi interface
2. Default destination for ICMP traffic can be made configurable
3. New configuration in gNB now makes it easy to configure UPF routes
   in case multiple interfaces exist

Still multiple interfaces & multiple gNBs support requires little bit of
work.