### PR TITLE
fix: Remove hardcoding for User Location Information

### DIFF
--- a/common/messages.go
+++ b/common/messages.go
@@ -7,6 +7,7 @@ package common
 import (
 	"github.com/omec-project/gnbsim/util/ngapTestpacket"
 	"github.com/omec-project/gnbsim/util/test"
+	"github.com/omec-project/openapi/models"
 
 	"github.com/omec-project/nas"
 	"github.com/omec-project/ngap/ngapType"
@@ -43,7 +44,8 @@ type NasPduList [][]byte
 // UuMessage is used to carry information between the UE and GNodeB
 type UuMessage struct {
 	DefaultMessage
-	Supi string
+	Supi           string
+	SelectedPlmnId *models.PlmnId
 
 	// Encoded NAS message
 	NasPdus  NasPduList

--- a/gnodeb/context/gnbcpue.go
+++ b/gnodeb/context/gnbcpue.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/omec-project/gnbsim/common"
 	"github.com/omec-project/gnbsim/logger"
+	"github.com/omec-project/ngap/ngapType"
 
 	"github.com/sirupsen/logrus"
 )
@@ -20,6 +21,7 @@ type GnbCpUe struct {
 	AmfUeNgapId int64
 	Amf         *GnbAmf
 	Gnb         *GNodeB
+	UeLocation  *ngapType.UserLocationInformationNR
 
 	// TODO: Sync map is not needed as it is handled single threaded
 	GnbUpUes sync.Map
@@ -36,11 +38,14 @@ type GnbCpUe struct {
 	Log *logrus.Entry
 }
 
-func NewGnbCpUe(ngapId int64, gnb *GNodeB, amf *GnbAmf) *GnbCpUe {
+func NewGnbCpUe(ngapId int64, gnb *GNodeB, amf *GnbAmf,
+	ueLoc *ngapType.UserLocationInformationNR) *GnbCpUe {
+
 	gnbue := GnbCpUe{}
 	gnbue.GnbUeNgapId = ngapId
 	gnbue.Amf = amf
 	gnbue.Gnb = gnb
+	gnbue.UeLocation = ueLoc
 	gnbue.ReadChan = make(chan common.InterfaceMessage, 5)
 	gnbue.Log = logger.GNodeBLog.WithFields(logrus.Fields{"subcategory": "GnbCpUe",
 		logger.FieldGnbUeNgapId: ngapId})

--- a/gnodeb/context/gnodeb.go
+++ b/gnodeb/context/gnodeb.go
@@ -5,12 +5,21 @@
 package context
 
 import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	"github.com/omec-project/aper"
 	transport "github.com/omec-project/gnbsim/transportcommon"
+	"github.com/omec-project/ngap/ngapConvert"
+	"github.com/omec-project/ngap/ngapType"
 
 	"github.com/omec-project/idgenerator"
 	"github.com/omec-project/openapi/models"
 	"github.com/sirupsen/logrus"
 )
+
+const MAX_CGI_BIT_LENGTH int32 = 36
 
 // GNodeB holds the context for a gNodeB. It manages the control plane and
 // user plane layer of a gNodeB.
@@ -50,6 +59,65 @@ func (gnb *GNodeB) GetDefaultAmf() *GnbAmf {
 
 func (gnb *GNodeB) AllocateRanUeNgapID() (int64, error) {
 	return gnb.RanUeNGAPIDGenerator.Allocate()
+}
+
+func (gnb *GNodeB) GetUserLocation(selectedPlmn *models.PlmnId) (*ngapType.UserLocationInformationNR, error) {
+	ueLocInfo := new(ngapType.UserLocationInformationNR)
+	ueLocInfo.NRCGI.PLMNIdentity = ngapConvert.PlmnIdToNgap(*gnb.RanId.PlmnId)
+
+	gnbId := gnb.RanId.GNbId
+
+	// CGI is formed by appending cell ID (4 - 14 bits) to gNB ID (22 - 32) bits
+	// We currently have gNB ID configured, so applying left shift operation
+	// according to its length. (The leftmost bits of the NR Cell Identity IE
+	// correspond to the gNB ID - TS 38.413)
+	gnbIdUint, err := strconv.ParseUint(gnbId.GNBValue, 16, int(gnbId.BitLength))
+	if err != nil {
+		return nil, fmt.Errorf("invalid gnbid configured:%v", err)
+	}
+	gnbIdUint = gnbIdUint << (MAX_CGI_BIT_LENGTH - gnbId.BitLength)
+	// Cell ID
+	gnbIdUint |= 0x01
+
+	cgi := fmt.Sprintf("%x", gnbIdUint)
+
+	// 36 bits sums up to odd byte count, so prepending 0 to make byte
+	// count as 40
+	cgi = "0" + cgi
+
+	bs, err := hex.DecodeString(cgi)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode hex string: %v", err)
+	}
+
+	ueLocInfo.NRCGI.NRCellIdentity.Value = aper.BitString{
+		Bytes:     bs,
+		BitLength: 36,
+	}
+
+	tai := gnb.GetTaiFromSelectedPLMN(selectedPlmn)
+	if tai == nil {
+		return nil, fmt.Errorf("plmn configured for ue is not supported by gnb. check supported ta list")
+	}
+	ueLocInfo.TAI = ngapConvert.TaiToNgap(*tai)
+	return ueLocInfo, nil
+}
+
+// GetTaiFromSelectedPLMN fetches the TAI corresponding to the selectedPlmn
+// from the Supported TA list in gNB
+func (gnb *GNodeB) GetTaiFromSelectedPLMN(selectedPlmn *models.PlmnId) *models.Tai {
+	for _, ta := range gnb.SupportedTaList {
+		for _, plmn := range ta.BroadcastPLMNList {
+			if plmn.PlmnId == *selectedPlmn {
+				tai := &models.Tai{
+					PlmnId: selectedPlmn,
+					Tac:    ta.Tac,
+				}
+				return tai
+			}
+		}
+	}
+	return nil
 }
 
 type SupportedTA struct {

--- a/gnodeb/gnodeb.go
+++ b/gnodeb/gnodeb.go
@@ -118,13 +118,22 @@ func PerformNgSetup(gnb *gnbctx.GNodeB, amf *gnbctx.GnbAmf) (bool, error) {
 
 // RequestConnection should be called by UE that is willing to connect to this GNodeB
 func RequestConnection(gnb *gnbctx.GNodeB, uemsg *common.UuMessage) (chan common.InterfaceMessage, error) {
-	ranUeNgapID, err := gnb.AllocateRanUeNgapID()
+
+	// When multiple PLMNs are configured under Supported TA in gNB, the
+	// Selected PLMN sent by UE is used to fetch the corresponding TAI from the
+	// Supported TA list. This can be useful to populate the User Location Info
+	// in the UL NGAP messages.
+	ueLoc, err := gnb.GetUserLocation(uemsg.SelectedPlmnId)
 	if err != nil {
-		gnb.Log.Errorln("AllocateRanUeNgapID returned:", err)
-		return nil, fmt.Errorf("failed to allocate ran ue ngap id")
+		return nil, fmt.Errorf("failed to derive user location:%v", err)
 	}
 
-	gnbUe := gnbctx.NewGnbCpUe(ranUeNgapID, gnb, gnb.DefaultAmf)
+	ranUeNgapID, err := gnb.AllocateRanUeNgapID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate ran ue ngap id:%v", err)
+	}
+
+	gnbUe := gnbctx.NewGnbCpUe(ranUeNgapID, gnb, gnb.DefaultAmf, ueLoc)
 	gnb.GnbUes.AddGnbCpUe(ranUeNgapID, gnbUe)
 
 	// TODO: Launching a GO Routine for gNB and handling the waitgroup

--- a/gnodeb/ngap/build.go
+++ b/gnodeb/ngap/build.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/omec-project/gnbsim/common"
 	gnbctx "github.com/omec-project/gnbsim/gnodeb/context"
 	"github.com/omec-project/gnbsim/util/ngapTestpacket"
 
@@ -61,6 +62,29 @@ func GetNGSetupRequest(gnb *gnbctx.GNodeB) ([]byte, error) {
 		}
 		supportedTaList.List = append(supportedTaList.List, supportedTaItem)
 	}
+
+	return ngap.Encoder(message)
+}
+
+func GetInitialUEMessage(gnbue *gnbctx.GnbCpUe, msg *common.UuMessage) ([]byte, error) {
+
+	message := ngapTestpacket.BuildInitialUEMessage(gnbue.GnbUeNgapId, msg.NasPdus[0], "")
+
+	lst := message.InitiatingMessage.Value.InitialUEMessage.ProtocolIEs.List
+	// User Location Information
+	ie := lst[2]
+	*(ie.Value.UserLocationInformation.UserLocationInformationNR) = *gnbue.UeLocation
+
+	return ngap.Encoder(message)
+}
+
+func GetUplinkNASTransport(gnbue *gnbctx.GnbCpUe, msg *common.UuMessage) ([]byte, error) {
+	message := ngapTestpacket.BuildUplinkNasTransport(gnbue.AmfUeNgapId, gnbue.GnbUeNgapId, msg.NasPdus[0])
+
+	lst := message.InitiatingMessage.Value.InitialUEMessage.ProtocolIEs.List
+	// User Location Information
+	ie := lst[3]
+	*(ie.Value.UserLocationInformation.UserLocationInformationNR) = *gnbue.UeLocation
 
 	return ngap.Encoder(message)
 }

--- a/gnodeb/worker/gnbcpueworker/handler.go
+++ b/gnodeb/worker/gnbcpueworker/handler.go
@@ -42,7 +42,7 @@ func HandleInitialUEMessage(gnbue *gnbctx.GnbCpUe,
 	intfcMsg common.InterfaceMessage) {
 
 	msg := intfcMsg.(*common.UuMessage)
-	sendMsg, err := test.GetInitialUEMessage(gnbue.GnbUeNgapId, msg.NasPdus[0], "")
+	sendMsg, err := ngap.GetInitialUEMessage(gnbue, msg)
 	if err != nil {
 		gnbue.Log.Errorln("GetInitialUEMessage failed:", err)
 		return
@@ -100,7 +100,7 @@ func HandleUlInfoTransfer(gnbue *gnbctx.GnbCpUe,
 
 	msg := intfcMsg.(*common.UuMessage)
 	gnbue.Log.Traceln("Creating Uplink NAS Transport Message")
-	sendMsg, err := test.GetUplinkNASTransport(gnbue.AmfUeNgapId, gnbue.GnbUeNgapId, msg.NasPdus[0])
+	sendMsg, err := ngap.GetUplinkNASTransport(gnbue, msg)
 	if err != nil {
 		gnbue.Log.Errorln("GetUplinkNASTransport failed:", err)
 		return

--- a/realue/handler.go
+++ b/realue/handler.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/omec-project/gnbsim/common"
 	realuectx "github.com/omec-project/gnbsim/realue/context"
-	"github.com/omec-project/gnbsim/realue/util"
 	"github.com/omec-project/gnbsim/realue/worker/pdusessworker"
 
 	realue_nas "github.com/omec-project/gnbsim/realue/nas"
@@ -33,21 +32,10 @@ const (
 func HandleRegRequestEvent(ue *realuectx.RealUe,
 	msg common.InterfaceMessage) (err error) {
 
-	ueSecurityCapability := ue.GetUESecurityCapability()
-
-	ue.Suci, err = util.SupiToSuci(ue.Supi, ue.Plmn)
+	nasPdu, err := realue_nas.GetRegistrationRequest(ue)
 	if err != nil {
-		ue.Log.Errorln("SupiToSuci returned:", err)
-		return fmt.Errorf("failed to derive suci")
+		return fmt.Errorf("failed to create registration request:%v", err)
 	}
-	mobileId5GS := nasType.MobileIdentity5GS{
-		Len:    uint16(len(ue.Suci)), // suci
-		Buffer: ue.Suci,
-	}
-
-	ue.Log.Traceln("Generating Registration Request Message")
-	nasPdu := nasTestpacket.GetRegistrationRequest(nasMessage.RegistrationType5GSInitialRegistration,
-		mobileId5GS, nil, ueSecurityCapability, nil, nil, nil)
 
 	m := formUuMessage(common.REG_REQUEST_EVENT, nasPdu)
 	SendToSimUe(ue, m)

--- a/realue/nas/build.go
+++ b/realue/nas/build.go
@@ -9,7 +9,10 @@ import (
 	"fmt"
 
 	realuectx "github.com/omec-project/gnbsim/realue/context"
+	"github.com/omec-project/gnbsim/realue/util"
 	"github.com/omec-project/gnbsim/util/nastestpacket"
+	"github.com/omec-project/nas/nasTestpacket"
+	"github.com/omec-project/nas/nasType"
 
 	"github.com/omec-project/nas/nasConvert"
 	"github.com/omec-project/nas/nasMessage"
@@ -30,8 +33,28 @@ func GetServiceRequest(ue *realuectx.RealUe) ([]byte, error) {
 	data := new(bytes.Buffer)
 	err := nasMsg.GmmMessageEncode(data)
 	if err != nil {
-		return nil, fmt.Errorf("encode failed:", err)
+		return nil, fmt.Errorf("encode failed:%v", err)
 	}
 
 	return data.Bytes(), nil
+}
+
+func GetRegistrationRequest(ue *realuectx.RealUe) ([]byte, error) {
+	ueSecurityCapability := ue.GetUESecurityCapability()
+
+	var err error
+	ue.Suci, err = util.SupiToSuci(ue.Supi, ue.Plmn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive suci from supi")
+	}
+	mobileId5GS := nasType.MobileIdentity5GS{
+		Len:    uint16(len(ue.Suci)), // suci
+		Buffer: ue.Suci,
+	}
+
+	ue.Log.Traceln("Generating Registration Request Message")
+	nasPdu := nasTestpacket.GetRegistrationRequest(nasMessage.RegistrationType5GSInitialRegistration,
+		mobileId5GS, nil, ueSecurityCapability, nil, nil, nil)
+
+	return nasPdu, nil
 }


### PR DESCRIPTION
    1) gNB will use the selected PLMN sent by Real UE
       to fetch the corresponding TAI from its configuration
    2) gNB will use the fetched TAI to populate the User
       Location Information in Uplink NGAP messages