### PR TITLE
(FIX) Removing old version of nas from go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,7 @@ github.com/omec-project/logger_util v1.1.0 h1:R7tT80+ML1HlK4OoTrNv/UK+2H/u2GdIFN
 github.com/omec-project/logger_util v1.1.0/go.mod h1:UkD09amIhlh8P0k82A6Uz/atiZGeFS3C2wd334CKpuY=
 github.com/omec-project/milenage v1.1.0 h1:yVBtBB4hd+SQx4gFkE6mZ8mfzO5na/1d2j31G6jYlCA=
 github.com/omec-project/milenage v1.1.0/go.mod h1:Tw5HLvxWEQN0JA+EXEVwZ17TL9adEZk3kWqKGgsNmHc=
+github.com/omec-project/nas v1.1.1/go.mod h1:WRl/gOe8pZATzTk5pHbAcqUuWbmLdVV/jzjnl5lCcJ8=
 github.com/omec-project/nas v1.1.3 h1:2GuvNz/1tr3M6wpHlcuDCOJaxAa3Fm54xt5Wggklwrg=
 github.com/omec-project/nas v1.1.3/go.mod h1:gXqi/IZwEGXno26X8wg8ITsAUiemRQ7PkIJOWP1NzGA=
 github.com/omec-project/ngap v1.1.0 h1:J9bkPEzzyGd1787nGY/aZVp3gckkZBoJB4tkTo59eyw=

--- a/go.sum
+++ b/go.sum
@@ -279,7 +279,6 @@ github.com/omec-project/logger_util v1.1.0 h1:R7tT80+ML1HlK4OoTrNv/UK+2H/u2GdIFN
 github.com/omec-project/logger_util v1.1.0/go.mod h1:UkD09amIhlh8P0k82A6Uz/atiZGeFS3C2wd334CKpuY=
 github.com/omec-project/milenage v1.1.0 h1:yVBtBB4hd+SQx4gFkE6mZ8mfzO5na/1d2j31G6jYlCA=
 github.com/omec-project/milenage v1.1.0/go.mod h1:Tw5HLvxWEQN0JA+EXEVwZ17TL9adEZk3kWqKGgsNmHc=
-github.com/omec-project/nas v1.1.1/go.mod h1:gXqi/IZwEGXno26X8wg8ITsAUiemRQ7PkIJOWP1NzGA=
 github.com/omec-project/nas v1.1.3 h1:2GuvNz/1tr3M6wpHlcuDCOJaxAa3Fm54xt5Wggklwrg=
 github.com/omec-project/nas v1.1.3/go.mod h1:gXqi/IZwEGXno26X8wg8ITsAUiemRQ7PkIJOWP1NzGA=
 github.com/omec-project/ngap v1.1.0 h1:J9bkPEzzyGd1787nGY/aZVp3gckkZBoJB4tkTo59eyw=


### PR DESCRIPTION
Having old version of `github.com/omec-project/nas` in the `go.sum` causes:
```shell
Executing action                                                                                                                                                                                                                       
:: + go mod download all                                                                                                                                                                                                               
:: verifying github.com/omec-project/nas@v1.1.1/go.mod: checksum mismatch                                                                                                                                                              
::   downloaded: h1:WRl/gOe8pZATzTk5pHbAcqUuWbmLdVV/jzjnl5lCcJ8=                                                                                                                                                                       
::   go.sum:     h1:gXqi/IZwEGXno26X8wg8ITsAUiemRQ7PkIJOWP1NzGA=                                                                                                                                                                       
::                                                                                                                                                                                                                                     
:: SECURITY ERROR  
```

This PR removes the old version of `nas`, since it's not used in the project anymore.