### PR TITLE
Allow registration to PLMNID other than 208-93

### DIFF
--- a/gnodeb/worker/gnbcpueworker/handler.go
+++ b/gnodeb/worker/gnbcpueworker/handler.go
@@ -55,7 +55,7 @@ func HandleInitialUEMessage(gnbue *gnbctx.GnbCpUe,
 		}
 		gnbue.Log.Traceln("Sent Uplink NAS Message to AMF")
 	} else {
-		sendMsg, err := test.GetInitialUEMessage(gnbue.GnbUeNgapId, msg.NasPdus[0], "")
+		sendMsg, err := ngap.GetInitialUEMessage(gnbue, msg.NasPdus[0])
 		if err != nil {
 			gnbue.Log.Errorln("GetInitialUEMessage failed:", err)
 			return
@@ -113,7 +113,7 @@ func HandleUlInfoTransfer(gnbue *gnbctx.GnbCpUe,
 
 	msg := intfcMsg.(*common.UuMessage)
 	gnbue.Log.Traceln("Creating Uplink NAS Transport Message")
-	sendMsg, err := test.GetUplinkNASTransport(gnbue.AmfUeNgapId, gnbue.GnbUeNgapId, msg.NasPdus[0])
+	sendMsg, err := ngap.GetUplinkNASTransport(gnbue, msg.NasPdus[0])
 	if err != nil {
 		gnbue.Log.Errorln("GetUplinkNASTransport failed:", err)
 		return
@@ -427,15 +427,7 @@ func HandleUeCtxReleaseCommand(gnbue *gnbctx.GnbCpUe,
 		}
 	}
 
-	var pduSessIds []int64
-	f := func(k interface{}, v interface{}) bool {
-		pduSessIds = append(pduSessIds, k.(int64))
-		return true
-	}
-	gnbue.GnbUpUes.Range(f)
-
-	ngapPdu, err := test.GetUEContextReleaseComplete(gnbue.AmfUeNgapId,
-		gnbue.GnbUeNgapId, pduSessIds)
+	ngapPdu, err := ngap.GetUEContextReleaseComplete(gnbue)
 	if err != nil {
 		fmt.Println("Failed to create UE Context Release Complete message")
 		return

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/omec-project/gnbsim/common"
@@ -62,10 +63,16 @@ func InitProfile(profile *profctx.Profile, summaryChan chan common.InterfaceMess
 	}
 
 	for count := 1; count <= profile.UeCount; count++ {
-		imsiStr := IMSI_PREFIX + strconv.Itoa(startImsi)
+		imsiStr := makeImsiStr(profile, startImsi)
 		initImsi(profile, gnb, imsiStr)
 		startImsi++
 	}
+}
+
+// makeImsiStr constructs IMSI string with specified integer value and proper length.
+func makeImsiStr(profile *profctx.Profile, imsi int) string {
+	s := strconv.Itoa(imsi)
+	return IMSI_PREFIX + strings.Repeat("0", max(0, len(profile.StartImsi)-len(s))) + s
 }
 
 func initImsi(profile *profctx.Profile, gnb *gnbctx.GNodeB, imsiStr string) {
@@ -127,7 +134,7 @@ func ExecuteProfile(profile *profctx.Profile, summaryChan chan common.InterfaceM
 				plock.Lock()
 				profile.UeCount = profile.UeCount + 1
 				imsi := profile.Imsi + profile.UeCount
-				imsiStr := IMSI_PREFIX + strconv.Itoa(imsi)
+				imsiStr := makeImsiStr(profile, imsi)
 				initImsi(profile, gnb, imsiStr)
 				pCtx := profile.PSimUe[imsiStr]
 				profile.Log.Infoln("pCtx ", pCtx)
@@ -151,7 +158,7 @@ func ExecuteProfile(profile *profctx.Profile, summaryChan chan common.InterfaceM
 	}()
 	imsi := profile.Imsi
 	for count := 1; count <= profile.UeCount; count++ {
-		imsiStr := IMSI_PREFIX + strconv.Itoa(imsi)
+		imsiStr := makeImsiStr(profile, imsi)
 		imsi++
 		wg.Add(1)
 		pCtx := profile.PSimUe[imsiStr]

--- a/realue/handler.go
+++ b/realue/handler.go
@@ -7,6 +7,7 @@ package realue
 import (
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/omec-project/gnbsim/common"
 	realuectx "github.com/omec-project/gnbsim/realue/context"
@@ -25,9 +26,8 @@ import (
 
 // TODO Remove the hardcoding
 const (
-	SN_NAME                        string = "5G:mnc093.mcc208.3gppnetwork.org"
-	SWITCH_OFF                     uint8  = 0
-	REQUEST_TYPE_EXISTING_PDU_SESS uint8  = 0x02
+	SWITCH_OFF                     uint8 = 0
+	REQUEST_TYPE_EXISTING_PDU_SESS uint8 = 0x02
 )
 
 func HandleRegRequestEvent(ue *realuectx.RealUe,
@@ -64,9 +64,13 @@ func HandleAuthResponseEvent(ue *realuectx.RealUe,
 
 	ue.NgKsi = nasConvert.SpareHalfOctetAndNgksiToModels(authReq.SpareHalfOctetAndNgksi)
 
+	mcc, _ := strconv.Atoi(ue.Plmn.Mcc)
+	mnc, _ := strconv.Atoi(ue.Plmn.Mnc)
+	snName := fmt.Sprintf("5G:mnc%03d.mcc%03d.3gppnetwork.org", mnc, mcc)
+
 	rand := authReq.GetRANDValue()
 	autn := authReq.GetAUTN()
-	resStat := ue.DeriveRESstarAndSetKey(autn[:], rand[:], SN_NAME)
+	resStat := ue.DeriveRESstarAndSetKey(autn[:], rand[:], snName)
 
 	// TODO: Parse Auth Request IEs and update the RealUE Context
 

--- a/realue/util/util.go
+++ b/realue/util/util.go
@@ -23,25 +23,12 @@ const (
 var ROUTING_INDICATOR []uint8 = []uint8{0xf0, 0xff}
 
 func SupiToSuci(supi string, plmnid *models.PlmnId) ([]byte, error) {
-	index := strings.Index(supi, "-")
-	if index < 0 {
-		return nil, fmt.Errorf(`invalid supi format, should start with "imsi-"`)
+	supiExpectedPrefix := "imsi-" + plmnid.Mcc + plmnid.Mnc
+	if !strings.HasPrefix(supi, supiExpectedPrefix) {
+		return nil, fmt.Errorf(`invalid supi format, should start with "imsi-" + MCC + MNC`)
 	}
-
-	// extracting imsi part after "imsi-"
-	imsi := supi[(index + 1):]
-
-	if !strings.Contains(imsi, plmnid.Mcc) {
-		return nil, fmt.Errorf("mcc not found in imsi")
-	}
-
-	index = strings.Index(imsi, plmnid.Mnc)
-	if index < 0 {
-		return nil, fmt.Errorf("mnc not found in imsi")
-	}
-	index += len(plmnid.Mnc)
-	// extracting msin from imsi
-	msin := imsi[index:]
+	// extracting msin from supi
+	msin := supi[len(supiExpectedPrefix):]
 
 	suci := make([]uint8, 0, SUCI_LEN)
 	// creating octet 4 of 5GS mobile identity info


### PR DESCRIPTION
This patch fixes several bugs in UE and gNB, to make it possible to register the UE to a core network with MCC=001 MNC=01.
This has been tested with free5GC, for **uetriggservicereq** and **deregister** procedures. Test log: [free5gc.zip](https://github.com/omec-project/gnbsim/files/14040839/free5gc.zip)
Resolves #68.
Closes #88.

## `initImsi` and other places in profile package

The IMSI is converted to integer and back to string without preserving its length.
When MCC is set to 001, this removes the leading zeros, resulting in mismatched IMSI.

## `SupiToSuci`

MCC and MNC are searched, separately, in the IMSI.
When MNC happens to be a substring of MCC, this results in incorrect MSIN.
For example, an input of "imsi-001017005551000" would result in MSIN "017005551000" instead of "7005551000".

## `SN_NAME`

208-93 was hard-coded in `SN_NAME` constant.
This is replaced with a dynamic construction according to UE's PLMNID.

## `HandleInitialUEMessage` and other places in gnbcpueworker package

ngapTestpacket package generates messages with hard-coded 208-93 TAC=1 in UserLocationInformation IE.
This is wrapped with updating procedures in gnodeb/ngap package.
