### PR TITLE
enable linters: `typecheck`, `gci` and `whitespace`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -235,7 +235,7 @@ linters:
     - unused
     - gosimple
     - ineffassign
-    # - typecheck
+    - typecheck
     # Additional
     # - lll
     - godox
@@ -245,10 +245,10 @@ linters:
     # - nestif
     # - gomodguard
     # - nakedret
-    # - gci
+    - gci
     - misspell
     - gofumpt
-    # - whitespace
+    - whitespace
     # - unconvert
     # - predeclared
     # - noctx

--- a/common/messages.go
+++ b/common/messages.go
@@ -7,7 +7,6 @@ package common
 import (
 	"github.com/omec-project/gnbsim/util/ngapTestpacket"
 	"github.com/omec-project/gnbsim/util/test"
-
 	"github.com/omec-project/nas"
 	"github.com/omec-project/ngap/ngapType"
 )

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -13,9 +13,8 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/omec-project/gnbsim/logger"
+	"gopkg.in/yaml.v2"
 )
 
 var AppConfig *Config

--- a/gnbsim.go
+++ b/gnbsim.go
@@ -24,7 +24,6 @@ import (
 	prof "github.com/omec-project/gnbsim/profile"
 	profctx "github.com/omec-project/gnbsim/profile/context"
 	"github.com/omec-project/gnbsim/stats"
-
 	"github.com/urfave/cli"
 )
 

--- a/gnodeb/context/gnbamf.go
+++ b/gnodeb/context/gnbamf.go
@@ -7,10 +7,9 @@ package context
 import (
 	"net"
 
-	"github.com/omec-project/gnbsim/logger"
-
 	amfctx "github.com/omec-project/amf/context"
 	"github.com/omec-project/amf/factory"
+	"github.com/omec-project/gnbsim/logger"
 	"github.com/omec-project/openapi/models"
 	"github.com/sirupsen/logrus"
 )

--- a/gnodeb/context/gnbcpue.go
+++ b/gnodeb/context/gnbcpue.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/omec-project/gnbsim/common"
 	"github.com/omec-project/gnbsim/logger"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/gnodeb/context/gnbpeerdao.go
+++ b/gnodeb/context/gnbpeerdao.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/omec-project/gnbsim/logger"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/gnodeb/context/gnbuedao.go
+++ b/gnodeb/context/gnbuedao.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/omec-project/gnbsim/logger"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/gnodeb/context/gnbupf.go
+++ b/gnodeb/context/gnbupf.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/omec-project/gnbsim/common"
 	"github.com/omec-project/gnbsim/logger"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/gnodeb/context/gnbupue.go
+++ b/gnodeb/context/gnbupue.go
@@ -7,7 +7,6 @@ package context
 import (
 	"github.com/omec-project/gnbsim/common"
 	"github.com/omec-project/gnbsim/logger"
-
 	"github.com/omec-project/ngap/ngapType"
 	"github.com/omec-project/openapi/models"
 	"github.com/sirupsen/logrus"

--- a/gnodeb/context/gnodeb.go
+++ b/gnodeb/context/gnodeb.go
@@ -6,7 +6,6 @@ package context
 
 import (
 	transport "github.com/omec-project/gnbsim/transportcommon"
-
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/util/idgenerator"
 	"github.com/sirupsen/logrus"

--- a/gnodeb/gnodeb.go
+++ b/gnodeb/gnodeb.go
@@ -18,7 +18,6 @@ import (
 	"github.com/omec-project/gnbsim/gnodeb/worker/gnbamfworker"
 	"github.com/omec-project/gnbsim/gnodeb/worker/gnbcpueworker"
 	"github.com/omec-project/gnbsim/logger"
-
 	"github.com/omec-project/util/idgenerator"
 )
 

--- a/gnodeb/ngap/build.go
+++ b/gnodeb/ngap/build.go
@@ -14,7 +14,6 @@ import (
 	"github.com/omec-project/aper"
 	gnbctx "github.com/omec-project/gnbsim/gnodeb/context"
 	"github.com/omec-project/gnbsim/util/ngapTestpacket"
-
 	"github.com/omec-project/ngap"
 	"github.com/omec-project/ngap/ngapConvert"
 	"github.com/omec-project/ngap/ngapType"

--- a/gnodeb/transport/cptransport.go
+++ b/gnodeb/transport/cptransport.go
@@ -11,14 +11,13 @@ import (
 	"syscall"
 	"time"
 
+	"git.cs.nctu.edu.tw/calee/sctp"
 	gnbctx "github.com/omec-project/gnbsim/gnodeb/context"
 	"github.com/omec-project/gnbsim/gnodeb/worker/gnbamfworker"
 	"github.com/omec-project/gnbsim/logger"
 	"github.com/omec-project/gnbsim/stats"
 	"github.com/omec-project/gnbsim/transportcommon"
 	"github.com/omec-project/gnbsim/util/test"
-
-	"git.cs.nctu.edu.tw/calee/sctp"
 	"github.com/sirupsen/logrus"
 )
 

--- a/gnodeb/transport/uptransport.go
+++ b/gnodeb/transport/uptransport.go
@@ -13,7 +13,6 @@ import (
 	gnbctx "github.com/omec-project/gnbsim/gnodeb/context"
 	"github.com/omec-project/gnbsim/logger"
 	"github.com/omec-project/gnbsim/transportcommon"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/gnodeb/worker/gnbamfworker/handler.go
+++ b/gnodeb/worker/gnbamfworker/handler.go
@@ -6,12 +6,10 @@
 package gnbamfworker
 
 import (
-	"github.com/omec-project/gnbsim/common"
-	"github.com/omec-project/gnbsim/util/test"
-
-	gnbctx "github.com/omec-project/gnbsim/gnodeb/context"
-
 	amfctx "github.com/omec-project/amf/context"
+	"github.com/omec-project/gnbsim/common"
+	gnbctx "github.com/omec-project/gnbsim/gnodeb/context"
+	"github.com/omec-project/gnbsim/util/test"
 	"github.com/omec-project/ngap/ngapConvert"
 	"github.com/omec-project/ngap/ngapType"
 	"github.com/omec-project/openapi/models"

--- a/gnodeb/worker/gnbamfworker/worker.go
+++ b/gnodeb/worker/gnbamfworker/worker.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/omec-project/gnbsim/common"
 	gnbctx "github.com/omec-project/gnbsim/gnodeb/context"
-
 	"github.com/omec-project/ngap"
 	"github.com/omec-project/ngap/ngapType"
 )

--- a/gnodeb/worker/gnbcpueworker/handler.go
+++ b/gnodeb/worker/gnbcpueworker/handler.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/omec-project/aper"
 	"github.com/omec-project/gnbsim/common"
 	gnbctx "github.com/omec-project/gnbsim/gnodeb/context"
 	"github.com/omec-project/gnbsim/gnodeb/ngap"
@@ -18,8 +19,6 @@ import (
 	"github.com/omec-project/gnbsim/stats"
 	"github.com/omec-project/gnbsim/util/ngapTestpacket"
 	"github.com/omec-project/gnbsim/util/test"
-
-	"github.com/omec-project/aper"
 	"github.com/omec-project/ngap/ngapConvert"
 	"github.com/omec-project/ngap/ngapType"
 )
@@ -498,7 +497,6 @@ func ProcessPduSessResourceSetupList(gnbue *gnbctx.GnbCpUe,
 	var nasPdus common.NasPduList
 
 	for _, item := range lst {
-
 		resourceSetupRequestTransfer := ngapType.PDUSessionResourceSetupRequestTransfer{}
 		err := aper.UnmarshalWithParams(item.PDUSessionResourceSetupRequestTransfer,
 			&resourceSetupRequestTransfer, "valueExt")

--- a/gnodeb/worker/gnbupfworker/worker.go
+++ b/gnodeb/worker/gnbupfworker/worker.go
@@ -11,7 +11,6 @@ import (
 	gnbctx "github.com/omec-project/gnbsim/gnodeb/context"
 	"github.com/omec-project/gnbsim/logger"
 	"github.com/omec-project/gnbsim/util/test"
-
 	"github.com/omec-project/ngap/ngapType"
 )
 

--- a/profile/context/profile.go
+++ b/profile/context/profile.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/omec-project/gnbsim/common"
 	"github.com/omec-project/gnbsim/logger"
-
 	"github.com/omec-project/openapi/models"
 	"github.com/sirupsen/logrus"
 )

--- a/profile/httprouter/router.go
+++ b/profile/httprouter/router.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/gnbsim/logger"
 	"github.com/omec-project/logger_util"
 )

--- a/realue/context/pdusession.go
+++ b/realue/context/pdusession.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/omec-project/gnbsim/common"
 	"github.com/omec-project/gnbsim/logger"
-
 	"github.com/omec-project/openapi/models"
 	"github.com/sirupsen/logrus"
 )

--- a/realue/context/realue.go
+++ b/realue/context/realue.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/omec-project/gnbsim/common"
 	"github.com/omec-project/gnbsim/logger"
-
 	"github.com/omec-project/nas/nasMessage"
 	"github.com/omec-project/nas/nasType"
 	"github.com/omec-project/nas/security"

--- a/realue/handler.go
+++ b/realue/handler.go
@@ -11,12 +11,10 @@ import (
 
 	"github.com/omec-project/gnbsim/common"
 	realuectx "github.com/omec-project/gnbsim/realue/context"
+	realue_nas "github.com/omec-project/gnbsim/realue/nas"
 	"github.com/omec-project/gnbsim/realue/util"
 	"github.com/omec-project/gnbsim/realue/worker/pdusessworker"
 	"github.com/omec-project/gnbsim/stats"
-
-	realue_nas "github.com/omec-project/gnbsim/realue/nas"
-
 	"github.com/omec-project/nas"
 	"github.com/omec-project/nas/nasConvert"
 	"github.com/omec-project/nas/nasMessage"
@@ -435,7 +433,6 @@ func HandleDlInfoTransferEvent(ue *realuectx.RealUe,
 			}
 			nasMsg = m
 			msgType = nasMsg.GsmHeader.GetMessageType()
-
 		}
 
 		m := &common.UeMessage{}

--- a/realue/nas/build.go
+++ b/realue/nas/build.go
@@ -10,7 +10,6 @@ import (
 
 	realuectx "github.com/omec-project/gnbsim/realue/context"
 	"github.com/omec-project/gnbsim/util/nastestpacket"
-
 	"github.com/omec-project/nas/nasConvert"
 	"github.com/omec-project/nas/nasMessage"
 )

--- a/realue/nas/nas_security.go
+++ b/realue/nas/nas_security.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	realuectx "github.com/omec-project/gnbsim/realue/context"
-
 	"github.com/omec-project/nas"
 	"github.com/omec-project/nas/nasMessage"
 	"github.com/omec-project/nas/security"

--- a/realue/worker/pdusessworker/handler.go
+++ b/realue/worker/pdusessworker/handler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/omec-project/gnbsim/common"
 	realuectx "github.com/omec-project/gnbsim/realue/context"
 	"github.com/omec-project/gnbsim/util/test"
-
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 )

--- a/simue/context/simue.go
+++ b/simue/context/simue.go
@@ -12,7 +12,6 @@ import (
 	"github.com/omec-project/gnbsim/logger"
 	profctx "github.com/omec-project/gnbsim/profile/context"
 	realuectx "github.com/omec-project/gnbsim/realue/context"
-
 	"github.com/omec-project/nas/security"
 	"github.com/sirupsen/logrus"
 )

--- a/util/test/ranUe.go
+++ b/util/test/ranUe.go
@@ -9,8 +9,6 @@ import (
 	"regexp"
 
 	"github.com/calee0219/fatal"
-	"golang.org/x/net/ipv4"
-
 	"github.com/omec-project/CommonConsumerTestData/UDR/TestRegistrationProcedure"
 	"github.com/omec-project/nas/nasMessage"
 	"github.com/omec-project/nas/nasType"
@@ -18,6 +16,7 @@ import (
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/util/milenage"
 	"github.com/omec-project/util/ueauth"
+	"golang.org/x/net/ipv4"
 )
 
 type RanUeContext struct {


### PR DESCRIPTION
Tested changes with OnRamp with profiles 1-5 and 7