### PR TITLE
Enable linters: `nakedret`, `unconvert`, `predeclared`, `noctx`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -244,14 +244,14 @@ linters:
     # - gocognit
     # - nestif
     # - gomodguard
-    # - nakedret
+    - nakedret
     - gci
     - misspell
     - gofumpt
     - whitespace
-    # - unconvert
-    # - predeclared
-    # - noctx
+    - unconvert
+    - predeclared
+    - noctx
     - dogsled
     # - bodyclose
     - asciicheck

--- a/gnodeb/context/gnbamf.go
+++ b/gnodeb/context/gnbamf.go
@@ -67,8 +67,8 @@ func (amf *GnbAmf) SetAMFName(name string) {
 	amf.AmfName = name
 }
 
-func (amf *GnbAmf) SetRelativeAMFCapacity(cap int64) {
-	amf.RelCap = cap
+func (amf *GnbAmf) SetRelativeAMFCapacity(relativeCapacity int64) {
+	amf.RelCap = relativeCapacity
 }
 
 func (amf *GnbAmf) SetNgSetupStatus(successfulOutcome bool) {

--- a/gnodeb/transport/cptransport.go
+++ b/gnodeb/transport/cptransport.go
@@ -61,8 +61,7 @@ func (cpTprt *GnbCpTransport) ConnectToPeer(peer transportcommon.TransportPeer) 
 		amf.AmfIp = addrs[0]
 	}
 
-	amf.Conn, err = test.ConnectToAmf(amf.AmfIp, gnb.GnbN2Ip, int(amf.AmfPort),
-		int(gnb.GnbN2Port))
+	amf.Conn, err = test.ConnectToAmf(amf.AmfIp, gnb.GnbN2Ip, amf.AmfPort, gnb.GnbN2Port)
 	if err != nil {
 		return fmt.Errorf("failed to connect amf, ip: %v, port: %v, err: %v",
 			amf.AmfIp, amf.AmfPort, err)

--- a/gnodeb/worker/gnbcpueworker/worker.go
+++ b/gnodeb/worker/gnbcpueworker/worker.go
@@ -44,7 +44,6 @@ func HandleEvents(gnbue *gnbctx.GnbCpUe) (err error) {
 			HandleRanConnectionRelease(gnbue, msg)
 		case common.QUIT_EVENT:
 			HandleQuitEvent(gnbue, msg)
-			return
 		default:
 			gnbue.Log.Infoln("Event", evt, "is not supported")
 		}

--- a/realue/handler.go
+++ b/realue/handler.go
@@ -245,7 +245,7 @@ func HandlePduSessEstAcceptEvent(ue *realuectx.RealUe,
 	pduSess.SscMode = nasMsg.GetSSCMode()
 	pduSess.PduAddress = pduAddr
 	pduSess.WriteUeChan = ue.ReadChan
-	ue.AddPduSession(int64(pduSess.PduSessId), pduSess)
+	ue.AddPduSession(pduSess.PduSessId, pduSess)
 	ue.Log.Infoln("PDU Session ID:", pduSess.PduSessId)
 	ue.Log.Infoln("PDU Session Type:", pduSess.PduSessType)
 	ue.Log.Infoln("SSC Mode:", pduSess.SscMode)
@@ -302,8 +302,7 @@ func HandlePduSessReleaseCompleteEvent(ue *realuectx.RealUe,
 	nasPdu, err = realue_nas.EncodeNasPduWithSecurity(ue, nasPdu,
 		nas.SecurityHeaderTypeIntegrityProtectedAndCiphered, true)
 	if err != nil {
-		fmt.Println("Failed to encrypt PDU Session Release Request Message", err)
-		return
+		return fmt.Errorf("failed to encrypt PDU Session Release Request Message: %v", err)
 	}
 
 	m := formUuMessage(common.PDU_SESS_REL_COMPLETE_EVENT, nasPdu, 0)

--- a/realue/worker/pdusessworker/handler.go
+++ b/realue/worker/pdusessworker/handler.go
@@ -41,7 +41,7 @@ func SendIcmpEchoRequest(pduSess *realuectx.PduSession) (err error) {
 	icmpPayload, err := hex.DecodeString("8c870d0000000000101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637")
 	if err != nil {
 		pduSess.Log.Errorln("Failed to decode icmp hexString ")
-		return
+		return err
 	}
 	icmpPayloadLen := len(icmpPayload)
 	pduSess.Log.Traceln("ICMP payload size:", icmpPayloadLen)
@@ -63,7 +63,7 @@ func SendIcmpEchoRequest(pduSess *realuectx.PduSession) (err error) {
 	v4HdrBuf, err := ipv4hdr.Marshal()
 	if err != nil {
 		pduSess.Log.Errorln("ipv4hdr header marshal failed")
-		return
+		return err
 	}
 
 	icmpMsg := icmp.Message{
@@ -76,7 +76,7 @@ func SendIcmpEchoRequest(pduSess *realuectx.PduSession) (err error) {
 	b, err := icmpMsg.Marshal(nil)
 	if err != nil {
 		pduSess.Log.Errorln("Failed to marshal icmp message")
-		return
+		return err
 	}
 
 	payload := append(v4HdrBuf, b...)


### PR DESCRIPTION
Tested changes with OnRamp with profiles 1-5 and 7