### PR TITLE
chore: enable staticcheck and govet in ci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,15 +21,15 @@ linters:
     - goconst
     - godox
     - gomodguard
+    - govet
     - misspell
     - nakedret
     - noctx
     - predeclared
+    - staticcheck
     - unconvert
     - unparam
     - whitespace
-  disable:
-    - staticcheck
   settings:
     errcheck:
       check-type-assertions: false

--- a/common/procedures.go
+++ b/common/procedures.go
@@ -47,7 +47,7 @@ func (id ProcedureType) String() string {
 }
 
 func GetProcId(name string) ProcedureType {
-	var p ProcedureType = UNKNOWN_PROCEDURE
+	p := UNKNOWN_PROCEDURE
 	for id, v := range procStrMap {
 		if v == name {
 			return id

--- a/gnodeb/worker/gnbcpueworker/handler.go
+++ b/gnodeb/worker/gnbcpueworker/handler.go
@@ -364,14 +364,15 @@ func HandleDataBearerSetupResponse(gnbue *gnbctx.GnbCpUe,
 	var ngapPdu []byte
 	var err error
 
-	if msg.TriggeringEvent == common.PDU_SESS_RESOURCE_SETUP_REQUEST_EVENT {
+	switch msg.TriggeringEvent {
+	case common.PDU_SESS_RESOURCE_SETUP_REQUEST_EVENT:
 		ngapPdu, err = test.GetPDUSessionResourceSetupResponse(pduSessions,
 			gnbue.AmfUeNgapId, gnbue.GnbUeNgapId, gnbue.Gnb.GnbN3Ip)
 		if err != nil {
 			gnbue.Log.Errorln("failed to create PDU Session Resource Setup Response:", err)
 			return
 		}
-	} else if msg.TriggeringEvent == common.INITIAL_CTX_SETUP_REQUEST_EVENT {
+	case common.INITIAL_CTX_SETUP_REQUEST_EVENT:
 		ngapPdu, err = test.GetInitialContextSetupResponseForServiceRequest(pduSessions,
 			gnbue.AmfUeNgapId, gnbue.GnbUeNgapId, gnbue.Gnb.GnbN3Ip)
 		if err != nil {

--- a/realue/handler.go
+++ b/realue/handler.go
@@ -418,8 +418,8 @@ func HandleDlInfoTransferEvent(ue *realuectx.RealUe,
 
 		if msgType == nas.MsgTypeDLNASTransport {
 			ue.Log.Info("Payload contaner type:",
-				nasMsg.GmmMessage.DLNASTransport.SpareHalfOctetAndPayloadContainerType)
-			payload := nasMsg.GmmMessage.DLNASTransport.PayloadContainer
+				nasMsg.DLNASTransport.SpareHalfOctetAndPayloadContainerType)
+			payload := nasMsg.DLNASTransport.PayloadContainer
 			if payload.Len == 0 {
 				return fmt.Errorf("payload container length is 0")
 			}

--- a/realue/nas/build.go
+++ b/realue/nas/build.go
@@ -16,7 +16,7 @@ import (
 
 func GetServiceRequest(ue *realuectx.RealUe) ([]byte, error) {
 	nasMsg := nastestpacket.BuildServiceRequest(nasMessage.ServiceTypeData)
-	serviceRequest := nasMsg.GmmMessage.ServiceRequest
+	serviceRequest := nasMsg.ServiceRequest
 
 	guti := nasConvert.GutiToNas(ue.Guti)
 	serviceRequest.SetTypeOfIdentity(nasMessage.MobileIdentity5GSType5gSTmsi)

--- a/realue/nas/nas_security.go
+++ b/realue/nas/nas_security.go
@@ -60,7 +60,7 @@ func GetNasPduSetupRequest(ue *realuectx.RealUe, msg *ngapType.PDUSessionResourc
 					ue.Log.Infoln("Found NAS PDU inside ResourceSEtupList")
 					pkg := []byte(ie1.PDUSessionNASPDU.Value)
 					m, err := NASDecode(ue, nas.GetSecurityHeaderType(pkg), pkg)
-					ue.Log.Infoln("UE address:", m.GmmMessage.DLNASTransport.Ipaddr)
+					ue.Log.Infoln("UE address:", m.Ipaddr)
 					if err != nil {
 						return nil
 					}
@@ -89,7 +89,7 @@ func NASEncode(ue *realuectx.RealUe, msg *nas.Message, securityContextAvailable 
 		return msg.PlainNasEncode()
 	} else {
 		needCiphering := false
-		switch msg.SecurityHeader.SecurityHeaderType {
+		switch msg.SecurityHeaderType {
 		case nas.SecurityHeaderTypeIntegrityProtected:
 			ue.Log.Debugln("security header type: Integrity Protected")
 		case nas.SecurityHeaderTypeIntegrityProtectedAndCiphered:
@@ -105,7 +105,7 @@ func NASEncode(ue *realuectx.RealUe, msg *nas.Message, securityContextAvailable 
 			ue.DLCount.Set(0, 0)
 			needCiphering = true
 		default:
-			return nil, fmt.Errorf("wrong security header type: 0x%0x", msg.SecurityHeader.SecurityHeaderType)
+			return nil, fmt.Errorf("wrong security header type: 0x%0x", msg.SecurityHeaderType)
 		}
 
 		payload, err = msg.PlainNasEncode()
@@ -135,7 +135,7 @@ func NASEncode(ue *realuectx.RealUe, msg *nas.Message, securityContextAvailable 
 		// Add mac value
 		payload = append(mac32, payload[:]...)
 		// Add EPD and Security Type
-		msgSecurityHeader := []byte{msg.SecurityHeader.ProtocolDiscriminator, msg.SecurityHeader.SecurityHeaderType}
+		msgSecurityHeader := []byte{msg.ProtocolDiscriminator, msg.SecurityHeaderType}
 		payload = append(msgSecurityHeader, payload[:]...)
 
 		// Increase UL Count
@@ -195,7 +195,7 @@ func NASDecode(ue *realuectx.RealUe, securityHeaderType uint8, payload []byte) (
 			ciphered = true
 			ue.DLCount.Set(0, 0)
 		default:
-			return nil, fmt.Errorf("wrong security header type: 0x%0x", msg.SecurityHeader.SecurityHeaderType)
+			return nil, fmt.Errorf("wrong security header type: 0x%0x", msg.SecurityHeaderType)
 		}
 		// Caculate ul count
 		if ue.DLCount.SQN() > sequenceNumber {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -248,6 +248,7 @@ func readStats() {
 			logger.StatsLog.Infoln("Received Event: UE_CTX_CMD_IN: ", m)
 			t := popTrans(m.Id) // remove MSG in trans but use the time msg was received
 			if t == nil {
+				continue
 			}
 			m.T = t.T
 			ue := getUe(m.Supi)

--- a/util/nastestpacket/build.go
+++ b/util/nastestpacket/build.go
@@ -39,6 +39,6 @@ func BuildServiceRequest(serviceType uint8) *nas.Message {
 	case nasMessage.ServiceTypeSignalling:
 	}
 
-	m.GmmMessage.ServiceRequest = serviceRequest
+	m.ServiceRequest = serviceRequest
 	return m
 }

--- a/util/test/gtp.go
+++ b/util/test/gtp.go
@@ -71,7 +71,7 @@ func BuildGTPv1Header(extHdrFlag bool, snFlag bool, nPduFlag bool,
 	var optHdrPresent bool
 
 	/* Setting GTP-U header flags */
-	var flags uint8 = FLAG_GTP_VERSION_1 | FLAG_PROTOCOL_TYPE_GTP
+	flags := FLAG_GTP_VERSION_1 | FLAG_PROTOCOL_TYPE_GTP
 	if extHdrFlag {
 		flags |= FLAG_EXT_HEADER
 		optHdrPresent = true


### PR DESCRIPTION
This PR enables `staticcheck` and `govet` in the CI

- `GmmMessage` is embedded in `NasMessage` type so we wan access to the sub elements directly
- govet's fieldalignment check stays disabled.