### PR TITLE
Properly update log to WARN to avoid misleading ERROR log

### DIFF
--- a/gnbsim.go
+++ b/gnbsim.go
@@ -124,7 +124,7 @@ func action(ctx context.Context, c *cli.Command) error {
 		// Keep running gnbsim as long as profiles are not finished
 		for _, profile := range config.Configuration.Profiles {
 			if !profile.Enable {
-				logger.AppLog.Errorln("disabled profileType ", profile.ProfileType)
+				logger.AppLog.Warnf("disabled profile %s [type: %s]", profile.Name, profile.ProfileType)
 				continue
 			}
 			profileWaitGrp.Add(1)


### PR DESCRIPTION
Also provide additional details (name and type)